### PR TITLE
Fix gray line in video player

### DIFF
--- a/app/src/main/java/com/futo/platformplayer/views/video/FutoVideoPlayer.kt
+++ b/app/src/main/java/com/futo/platformplayer/views/video/FutoVideoPlayer.kt
@@ -601,6 +601,7 @@ class FutoVideoPlayer : FutoVideoPlayerBase {
             val lp = background.layoutParams as ConstraintLayout.LayoutParams;
             lp.bottomMargin = 0;
             background.layoutParams = lp;
+            _videoView.setBackgroundColor(Color.parseColor("#FF000000"))
 
             gestureControl.hideControls();
             //videoControlsBar.visibility = View.GONE;
@@ -614,6 +615,7 @@ class FutoVideoPlayer : FutoVideoPlayerBase {
             val lp = background.layoutParams as ConstraintLayout.LayoutParams;
             lp.bottomMargin = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 6.0f, Resources.getSystem().displayMetrics).toInt();
             background.layoutParams = lp;
+            _videoView.setBackgroundColor(Color.parseColor("#00000000"))
 
             gestureControl.hideControls();
             //videoControlsBar.visibility = View.VISIBLE;


### PR DESCRIPTION
This fixes the problem described in #315. I am not sure why there is a gray line, but this sets the video players background to black to hide the line when in fullscreen, thus fixing the issue.