### PR TITLE
Fix persist user sorting preference for downloaded videos

### DIFF
--- a/app/src/main/java/com/futo/platformplayer/stores/DownloadsOrderingStorage.kt
+++ b/app/src/main/java/com/futo/platformplayer/stores/DownloadsOrderingStorage.kt
@@ -1,0 +1,17 @@
+package com.futo.platformplayer.stores
+
+import kotlinx.serialization.*
+import kotlinx.serialization.json.Json
+
+@Serializable()
+class DownloadsOrderingStorage : FragmentedStorageFileJson() {
+    var ordering = "downloadDateDesc";
+
+    fun update(ord: String) {
+        ordering = ord
+        save();
+    }
+    override fun encode(): String {
+        return Json.encodeToString(this);
+    }
+}


### PR DESCRIPTION
This fixes the proble described in #2032 

Previously, the **sorting preference** for downloaded videos would reset when the user navigated away. Now, the sorting preference is saved and retained across sessions, improving user experience.
