### PR TITLE
Fix "previous song" button playing always from unshuffled queue, even when shuffle is used

### DIFF
--- a/app/src/main/java/com/futo/platformplayer/states/StatePlayer.kt
+++ b/app/src/main/java/com/futo/platformplayer/states/StatePlayer.kt
@@ -598,7 +598,7 @@ class StatePlayer {
             }
 
             if(_queuePosition < _queue.size) {
-                return _queue[_queuePosition];
+                return getCurrentQueueItem();
             }
         }
         return null;


### PR DESCRIPTION
Fix prevQueueItem always returning the item from _queue, even when _queueShuffled is active

Closes Issue [#729](https://github.com/futo-org/grayjay-android/issues/729)