### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -55,7 +55,7 @@
 
         <activity
             android:name=".activities.MainActivity"
-            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout"
             android:exported="true"
             android:theme="@style/Theme.FutoVideo.NoActionBar"
             android:launchMode="singleInstance"


### PR DESCRIPTION
resolves https://github.com/futo-org/grayjay-android/issues/47

> `android:configChanges`
> Lists configuration changes that the activity handles itself. When a configuration change occurs at runtime, the activity shuts down and restarts by default, but declaring a configuration with this attribute prevents the activity from restarting. Instead, the activity remains running and its [onConfigurationChanged()](https://developer.android.com/reference/android/app/Activity#onConfigurationChanged(android.content.res.Configuration)) method is called.

https://developer.android.com/guide/topics/manifest/activity-element#config