### PR TITLE
feat: add support to sort downloads by type

### DIFF
--- a/app/src/main/java/com/futo/platformplayer/fragment/mainactivity/main/DownloadsFragment.kt
+++ b/app/src/main/java/com/futo/platformplayer/fragment/mainactivity/main/DownloadsFragment.kt
@@ -263,8 +263,8 @@ class DownloadsFragment : MainFragment() {
                     "releasedDesc" -> vidsToReturn.sortedByDescending { it.datetime ?: OffsetDateTime.MIN }
                     "sizeAsc" -> vidsToReturn.sortedBy { it.videoSource.sumOf { it.fileSize } + it.audioSource.sumOf { it.fileSize } }
                     "sizeDesc" -> vidsToReturn.sortedByDescending { it.videoSource.sumOf { it.fileSize } + it.audioSource.sumOf { it.fileSize } }
-                    "typeAudio" -> vidsToReturn.filter { it.videoSource.isEmpty() && it.audioSource.isNotEmpty() }
-                    "typeVideo" -> vidsToReturn.filter { it.videoSource.isNotEmpty() }
+                    "typeAudio" -> vidsToReturn.sortedBy { if (it.videoSource.isEmpty() && it.audioSource.isNotEmpty()) 0 else 1 }
+                    "typeVideo" -> vidsToReturn.sortedBy { if (it.videoSource.isNotEmpty()) 0 else 1 }
                     else -> vidsToReturn
                 }
             }

--- a/app/src/main/java/com/futo/platformplayer/fragment/mainactivity/main/DownloadsFragment.kt
+++ b/app/src/main/java/com/futo/platformplayer/fragment/mainactivity/main/DownloadsFragment.kt
@@ -150,7 +150,7 @@ class DownloadsFragment : MainFragment() {
             spinnerSortBy.adapter = ArrayAdapter(context, R.layout.spinner_item_simple, resources.getStringArray(R.array.downloads_sortby_array)).also {
                 it.setDropDownViewResource(R.layout.spinner_dropdownitem_simple);
             };
-            val options = listOf("nameAsc", "nameDesc", "downloadDateAsc", "downloadDateDesc", "releasedAsc", "releasedDesc", "sizeAsc", "sizeDesc");
+            val options = listOf("nameAsc", "nameDesc", "downloadDateAsc", "downloadDateDesc", "releasedAsc", "releasedDesc", "sizeAsc", "sizeDesc", "typeAudio", "typeVideo");
             spinnerSortBy.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
                 override fun onItemSelected(parent: AdapterView<*>, view: View?, pos: Int, id: Long) {
                     when(pos) {
@@ -162,6 +162,8 @@ class DownloadsFragment : MainFragment() {
                         5 -> ordering.setAndSave("releasedDesc")
                         6 -> ordering.setAndSave("sizeAsc")
                         7 -> ordering.setAndSave("sizeDesc")
+                        8 -> ordering.setAndSave("typeAudio")
+                        9 -> ordering.setAndSave("typeVideo")
                         else -> ordering.setAndSave("")
                     }
                     updateContentFilters()
@@ -261,6 +263,8 @@ class DownloadsFragment : MainFragment() {
                     "releasedDesc" -> vidsToReturn.sortedByDescending { it.datetime ?: OffsetDateTime.MIN }
                     "sizeAsc" -> vidsToReturn.sortedBy { it.videoSource.sumOf { it.fileSize } + it.audioSource.sumOf { it.fileSize } }
                     "sizeDesc" -> vidsToReturn.sortedByDescending { it.videoSource.sumOf { it.fileSize } + it.audioSource.sumOf { it.fileSize } }
+                    "typeAudio" -> vidsToReturn.filter { it.videoSource.isEmpty() && it.audioSource.isNotEmpty() }
+                    "typeVideo" -> vidsToReturn.filter { it.videoSource.isNotEmpty() }
                     else -> vidsToReturn
                 }
             }

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -997,6 +997,8 @@
         <item>Data di Rilascio (Più Recente)</item>
         <item>Dimensione (Più Piccola)</item>
         <item>Dimensione (Più Grande)</item>
+        <item>Tipo (Solo Audio)</item>
+        <item>Tipo (Video)</item>
     </string-array>
     <string-array name="playlists_sortby_array">
         <item>Nome (Ascending)</item>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -960,6 +960,8 @@
         <item>Çıkış Tarihi (En Yeni)</item>
         <item>Boyut (En Küçük)</item>
         <item>Boyut (En Büyük)</item>
+        <item>Tür (Yalnızca Ses)</item>
+        <item>Tür (Video)</item>
     </string-array>
     <string-array name="feed_style">
         <item>Önizle</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1053,6 +1053,8 @@
         <item>Release Date (Newest)</item>
         <item>Size (Smallest)</item>
         <item>Size (Largest)</item>
+        <item>Type (Audio Only)</item>
+        <item>Type (Video)</item>
     </string-array>
     <string-array name="playlists_sortby_array">
         <item>Name (Ascending)</item>


### PR DESCRIPTION
This PR adds support to sort downloads by type (video/audio-only).

### Without downloads 

> See the new 2 items (Type - Audio Only / Video)

<img width="386" height="846" alt="empty-downloads" src="https://github.com/user-attachments/assets/7aa31f9f-8486-45b3-92cd-f82c8a9a20ef" />

---

### With some downloads

> There are 4 downloads, 2 videos and 2 audio-only

<img width="441" height="965" alt="with-downloads" src="https://github.com/user-attachments/assets/b72e08dc-9eec-4fc2-a983-0914a06b290c" />

---

### Sort by Audio

> Downloads sorted by audio, those are on top of the list

<img width="441" height="971" alt="sort-by-audio" src="https://github.com/user-attachments/assets/fb5fdba5-c9bd-465e-a369-68e7c707c4f8" />

---

### Sort by Video

> Downloads sorted by video, those are on top of the list

<img width="445" height="970" alt="sort-by-video" src="https://github.com/user-attachments/assets/671b0b28-ec7a-488b-b74f-ed6d1413b908" />

