### PR TITLE
Fix download of HLS videos

### DIFF
--- a/app/src/main/java/com/futo/platformplayer/downloads/VideoDownload.kt
+++ b/app/src/main/java/com/futo/platformplayer/downloads/VideoDownload.kt
@@ -168,6 +168,16 @@ class VideoDownload {
         (hasVideoRequestModifier && preparedVideoRequestModifier == null && videoSourceLive == null) ||
         (hasAudioRequestModifier && preparedAudioRequestModifier == null && audioSourceLive == null);
 
+    // HLS-specific: captured from the original JSSource before variant expansion.
+    // Variants are plain data classes without modifier support, so we preserve the
+    // modifier here for use during download.
+    @Contextual
+    @Transient
+    private var hlsVideoRequestModifier: IRequestModifier? = null;
+    @Contextual
+    @Transient
+    private var hlsAudioRequestModifier: IRequestModifier? = null;
+
     var progress: Double = 0.0;
     var isCancelled = false;
 
@@ -344,7 +354,10 @@ class VideoDownload {
                 for (source in original.video.videoSources) {
                     if (source is IHLSManifestSource) {
                         val sourceModifier = if (source is JSSource && source.hasRequestModifier) source.getRequestModifier() else null
-                        if (sourceModifier != null) preparedVideoRequestModifier = sourceModifier
+                        if (sourceModifier != null) {
+                            preparedVideoRequestModifier = sourceModifier
+                            hlsVideoRequestModifier = sourceModifier
+                        }
                         try {
                             val playlistResponse = client.get(source.url, HashMap(), sourceModifier)
                             if (playlistResponse.isOk) {
@@ -397,7 +410,10 @@ class VideoDownload {
                     for (source in video.audioSources) {
                         if (source is IHLSManifestAudioSource) {
                             val sourceModifier = if (source is JSSource && source.hasRequestModifier) source.getRequestModifier() else null
-                            if (sourceModifier != null) preparedAudioRequestModifier = sourceModifier
+                            if (sourceModifier != null) {
+                                preparedAudioRequestModifier = sourceModifier
+                                hlsAudioRequestModifier = sourceModifier
+                            }
                             try {
                                 val playlistResponse = client.get(source.url, HashMap(), sourceModifier)
                                 if (playlistResponse.isOk) {
@@ -539,9 +555,9 @@ class VideoDownload {
                             // HLS segments are concatenated into an MP4 file during download,
                             // so override the container for local playback/casting
                             videoOverrideContainer = "video/mp4";
-                            downloadHlsSource(context, "Video", client, videoModifier, videoSource!!.getVideoUrl(), File(downloadDir, videoFileName!!), progressCallback)
+                            downloadHlsSource(context, "Video", client, hlsVideoRequestModifier ?: videoModifier, videoSource!!.getVideoUrl(), File(downloadDir, videoFileName!!), progressCallback)
                         }
-                        else -> downloadFileSource("Video", client, videoModifier, videoSource!!.getVideoUrl(), File(downloadDir, videoFileName!!), progressCallback)
+                        else -> downloadFileSource("Video", client, hlsVideoRequestModifier ?: videoModifier, videoSource!!.getVideoUrl(), File(downloadDir, videoFileName!!), progressCallback)
                     }
                 else if(actualVideoSource is JSDashManifestRawSource) {
                     if(actualAudioSource == null)
@@ -589,9 +605,9 @@ class VideoDownload {
                             // HLS segments are concatenated into an MP4 file during download,
                             // so override the container for local playback/casting
                             audioOverrideContainer = "audio/mp4";
-                            downloadHlsSource(context, "Audio", client, audioModifier, audioSource!!.getAudioUrl(), File(downloadDir, audioFileName!!), progressCallback)
+                            downloadHlsSource(context, "Audio", client, hlsAudioRequestModifier ?: audioModifier, audioSource!!.getAudioUrl(), File(downloadDir, audioFileName!!), progressCallback)
                         }
-                        else -> downloadFileSource("Audio", client, audioModifier, audioSource!!.getAudioUrl(), File(downloadDir, audioFileName!!), progressCallback)
+                        else -> downloadFileSource("Audio", client, hlsAudioRequestModifier ?: audioModifier, audioSource!!.getAudioUrl(), File(downloadDir, audioFileName!!), progressCallback)
                     }
                 else if(actualAudioSource is JSDashManifestRawAudioSource) {
                     audioFileSize = downloadDashFileSource("Audio", client, actualAudioSource, File(downloadDir, audioFileName!!), progressCallback, 2);

--- a/app/src/test/java/com/futo/platformplayer/HlsDownloadAuthTests.kt
+++ b/app/src/test/java/com/futo/platformplayer/HlsDownloadAuthTests.kt
@@ -1,0 +1,119 @@
+package com.futo.platformplayer
+
+import com.futo.platformplayer.api.media.models.modifier.AdhocRequestModifier
+import com.futo.platformplayer.api.media.models.modifier.IRequest
+import com.futo.platformplayer.api.media.models.modifier.IRequestModifier
+import com.futo.platformplayer.api.media.models.streams.sources.HLSVariantAudioUrlSource
+import com.futo.platformplayer.api.media.models.streams.sources.HLSVariantVideoUrlSource
+import com.futo.platformplayer.api.media.models.streams.sources.IVideoUrlSource
+import com.futo.platformplayer.api.media.models.streams.sources.VideoUrlSource
+import com.futo.platformplayer.api.media.platforms.js.models.sources.JSSource
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class HlsDownloadAuthTests {
+
+    // Given an HLS variant from parseAndGetVideoSources
+    // Then it is NOT a JSSource, so VideoDownload.kt:503 `is JSSource` check fails
+    @Test
+    fun test_hlsVariantVideoUrlSource_isNotJSSource() {
+        val variant = HLSVariantVideoUrlSource(
+            name = "720p", width = 1280, height = 720,
+            container = "application/vnd.apple.mpegurl", codec = "avc1.64001f",
+            bitrate = 2560000, duration = 3600, priority = false,
+            url = "https://example.com/mid/index.m3u8"
+        )
+
+        assertFalse(
+            "HLSVariantVideoUrlSource is not a JSSource - root cause of auth loss",
+            variant is JSSource
+        )
+    }
+
+    // Given an HLS audio variant from parseAndGetAudioSources
+    // Then it is NOT a JSSource - same bug pattern as video (VideoDownload.kt:547)
+    @Test
+    fun test_hlsVariantAudioUrlSource_isNotJSSource() {
+        val variant = HLSVariantAudioUrlSource(
+            name = "audio", bitrate = 128000,
+            container = "application/vnd.apple.mpegurl", codec = "mp4a.40.2",
+            language = "en", duration = 3600, priority = false, original = true,
+            url = "https://example.com/audio/index.m3u8"
+        )
+
+        assertFalse(
+            "HLSVariantAudioUrlSource is not a JSSource - same auth bug as video",
+            variant is JSSource
+        )
+    }
+
+    // Given an HLSVariantVideoUrlSource converted to VideoUrlSource (prepare phase)
+    // When the download-time pattern `if (actualVideoSource is JSSource)` is applied
+    // Then the source for modifier extraction is null - auth is lost
+    @Test
+    fun test_downloadHlsSourcePattern_receivesNullModifier() {
+        // Given: HLS.parseAndGetVideoSources() returns a variant
+        val hlsVariant = HLSVariantVideoUrlSource(
+            name = "1080p", width = 1920, height = 1080,
+            container = "application/vnd.apple.mpegurl", codec = "avc1.640028",
+            bitrate = 7680000, duration = 3600, priority = false,
+            url = "https://example.com/high/index.m3u8"
+        )
+
+        // When: VideoDownload.kt:355 converts variant to VideoUrlSource
+        val videoSource = VideoUrlSource.fromUrlSource(hlsVariant)
+        assertNotNull("fromUrlSource should succeed", videoSource)
+
+        // When: VideoDownload.kt:503 extracts source for modifier
+        val actualVideoSource: IVideoUrlSource? = videoSource
+        val sourceForModifier = if (actualVideoSource is JSSource) actualVideoSource else null
+
+        // Then: sourceForModifier is null - downloadHlsSource gets no auth
+        assertNull(
+            "BUG: sourceForModifier is null because VideoUrlSource is not JSSource",
+            sourceForModifier
+        )
+    }
+
+    // Given an HLS manifest source with a requestModifier (auth)
+    // When expanded into variants and processed through the download pipeline
+    // Then the modifier IS preserved via separate storage (the fix)
+    @Test
+    fun test_hlsSourceWithModifier_shouldPreserveModifierThroughExpansion() {
+        // Given: original HLS source has auth modifier
+        val originalModifier: IRequestModifier = AdhocRequestModifier { url, headers ->
+            object : IRequest {
+                override val url: String = url
+                override val headers: Map<String, String> = headers + mapOf("Authorization" to "Bearer token123")
+            }
+        }
+
+        // Given: after expansion, variants are plain data classes
+        val expandedVariants = listOf(
+            HLSVariantVideoUrlSource("360p", 640, 360, "application/vnd.apple.mpegurl", "avc1", 1280000, 3600, false, "https://example.com/low/index.m3u8"),
+            HLSVariantVideoUrlSource("1080p", 1920, 1080, "application/vnd.apple.mpegurl", "avc1", 7680000, 3600, false, "https://example.com/high/index.m3u8")
+        )
+
+        // When: select best and apply prepare phase
+        val bestVariant = expandedVariants.maxByOrNull { it.height }!!
+        val videoSource = VideoUrlSource.fromUrlSource(bestVariant)
+
+        // When: THE FIX - modifier was captured during prepare, stored separately
+        // Simulating the fixed pattern: hlsVideoRequestModifier was set during prepare
+        val hlsVideoRequestModifier: IRequestModifier? = originalModifier  // captured during prepare
+
+        // When: at download time, use the captured modifier (with fallback for non-expanded sources)
+        val actualVideoSource = videoSource
+        val modifier = hlsVideoRequestModifier ?: (if (actualVideoSource is JSSource && actualVideoSource.hasRequestModifier) actualVideoSource.getRequestModifier() else null)
+
+        // Then: modifier IS available - auth is preserved
+        assertNotNull("modifier should be preserved through variant expansion via separate storage", modifier)
+
+        // Verify the modifier actually works
+        val request = modifier!!.modifyRequest("https://example.com/key.bin", emptyMap())
+        assertEquals("Bearer token123", request.headers["Authorization"])
+    }
+}


### PR DESCRIPTION
While working on an [issue](https://github.com/kaidelorenzo/grayjay-floatplane/pull/4) with the [Floatplane plugin](https://github.com/kaidelorenzo/grayjay-floatplane). I ran across an issue with the HLS download implementation.

Playback via HLS works fine, but downloading via HLS didn't work!

Basically what was happening here is that the request modifier function is not being kept preserved throughout the video download process. So the end result is an unauthenticated attempt to download the video (which will obviously fail).

I am no expert in this codebase, so extensive feedback and nitpicking is welcome and appreciated!

Note: I also had to fix a pre-existing test that was failing to compile, but I can drop this commit if someone else pushes a fix.

I had Claude do Red-Green testing, so it created a test. I can drop this if requested.

I don't know grayjay's policy on LLM contribution (I tried to find it), so I apologize if this change is unwanted due to how it was created.

LLMs used: Claude Opus 4.6 via opencode