### PR TITLE
feat: casting playback tracking

### DIFF
--- a/app/src/main/java/com/futo/platformplayer/casting/StateCasting.kt
+++ b/app/src/main/java/com/futo/platformplayer/casting/StateCasting.kt
@@ -58,6 +58,7 @@ import com.futo.platformplayer.views.casting.CastView.Companion
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -234,7 +235,19 @@ class StateCasting {
     fun startUpdateTimeJob(
         onTimeJobTimeChanged_s: Event1<Long>,
         setTime: (Long) -> Unit
-    ): Job? = null
+    ): Job? {
+        return CoroutineScope(Dispatchers.Main).launch {
+            while (isActive) {
+                val t_s = activeDevice?.expectedCurrentTime
+                if (t_s != null) {
+                    val t_ms = (t_s * 1000.0).toLong()
+                    setTime(t_ms)
+                    onTimeJobTimeChanged_s.emit(t_s.toLong())
+                }
+                kotlinx.coroutines.delay(1000)
+            }
+        }
+    }
 
     fun deviceFromInfo(deviceInfo: CastingDeviceInfo): CastingDevice? {
         try {

--- a/app/src/main/java/com/futo/platformplayer/fragment/mainactivity/main/VideoDetailView.kt
+++ b/app/src/main/java/com/futo/platformplayer/fragment/mainactivity/main/VideoDetailView.kt
@@ -1587,7 +1587,7 @@ class VideoDetailView : ConstraintLayout {
                             )
                         }
 
-                        if (me.video == video)
+                        if (me.video == video || (me.video?.url == video.url && !video.url.isNullOrBlank()))
                             me._playbackTracker = tracker;
                     } else if (me.video == video)
                         me._playbackTracker = null;

--- a/app/src/main/java/com/futo/platformplayer/fragment/mainactivity/main/VideoDetailView.kt
+++ b/app/src/main/java/com/futo/platformplayer/fragment/mainactivity/main/VideoDetailView.kt
@@ -745,20 +745,24 @@ class VideoDetailView : ConstraintLayout {
 
             StateCasting.instance.onActiveDeviceTimeChanged.subscribe(this) {
                 if (_isCasting) {
-                    setLastPositionMilliseconds((it * 1000.0).toLong(), true);
+                    val posMs = (it * 1000.0).toLong();
+                    setLastPositionMilliseconds(posMs, true);
                     _cast.setTime(lastPositionMilliseconds);
                     _timeBar.setPosition(it.toLong());
                     _timeBar.setBufferedPosition(0);
                     _timeBar.setDuration(video?.duration ?: 0);
+                    updatePlaybackTracking(posMs);
                 }
             };
 
             _cast.onTimeJobTimeChanged_s.subscribe {
                 if (_isCasting) {
-                    setLastPositionMilliseconds((it * 1000.0).toLong(), true);
+                    val posMs = (it * 1000.0).toLong();
+                    setLastPositionMilliseconds(posMs, true);
                     _timeBar.setPosition(it);
                     _timeBar.setBufferedPosition(0);
                     _timeBar.setDuration(video?.duration ?: 0);
+                    updatePlaybackTracking(posMs);
                 }
             }
         }

--- a/app/src/main/java/com/futo/platformplayer/views/casting/CastView.kt
+++ b/app/src/main/java/com/futo/platformplayer/views/casting/CastView.kt
@@ -256,7 +256,7 @@ class CastView : ConstraintLayout {
         stopTimeJob()
 
         if(isPlaying) {
-            StateCasting.instance.startUpdateTimeJob(
+            _updateTimeJob = StateCasting.instance.startUpdateTimeJob(
                 onTimeJobTimeChanged_s
             ) { setTime(it) }
 


### PR DESCRIPTION
This pull request should an issue where video watch history and view tracking were not being updated while casting. Previously, the background tasks and event listeners responsible for piping playback progression to the tracking systems were either stubbed out or disconnected during casting scenarios.

~~Note: While this wires up the Android architecture to support tracking during casts, the actual remote YouTube tracking still relies on the plugin's `source.getPlaybackTracker(url)` successfully returning a payload rather than `null`.~~ -> this was fixed after activating "Provide YouTube Activity" on the Grayjay app.