### PR TITLE
Persist subtitle setting across restarts with optional fallback to first found

### DIFF
--- a/app/src/main/java/com/futo/platformplayer/fragment/mainactivity/main/VideoDetailView.kt
+++ b/app/src/main/java/com/futo/platformplayer/fragment/mainactivity/main/VideoDetailView.kt
@@ -126,6 +126,7 @@ import com.futo.platformplayer.states.StateSubscriptions
 import com.futo.platformplayer.states.StateSync
 import com.futo.platformplayer.stores.FragmentedStorage
 import com.futo.platformplayer.stores.StringArrayStorage
+import com.futo.platformplayer.stores.StringStorage
 import com.futo.platformplayer.stores.db.types.DBHistory
 import com.futo.platformplayer.sync.internal.GJSyncOpcodes
 import com.futo.platformplayer.sync.models.SendToDevicePackage
@@ -364,7 +365,7 @@ class VideoDetailView : ConstraintLayout {
         Pair(-5 * 60, 30), //around 5 minutes, try every 30 seconds
         Pair(0, 10) //around live, try every 10 seconds
     );
-    private var _subtitleLanguage: String? = null
+    private var _subtitleLanguage: String? = _subtitleLanguageStore.value;
 
     @androidx.annotation.OptIn(UnstableApi::class)
     constructor(context: Context, attrs : AttributeSet? = null) : super(context, attrs) {
@@ -2807,6 +2808,7 @@ class VideoDetailView : ConstraintLayout {
         }
         _lastSubtitleSource = toSet;
         _subtitleLanguage = toSet?.language
+        _subtitleLanguageStore.setAndSave(_subtitleLanguage ?: "")
     }
 
     private fun handleUnavailableVideo(msg: String? = null) {
@@ -3641,6 +3643,7 @@ class VideoDetailView : ConstraintLayout {
         const val TAG_MORE = "MORE";
 
         private val _buttonPinStore = FragmentedStorage.get<StringArrayStorage>("videoPinnedButtons");
+        private val _subtitleLanguageStore = FragmentedStorage.get<StringStorage>("subtitleLanguage");
         private var _lastOfflinePlaybackToastTime: Long = 0
     }
 }


### PR DESCRIPTION
Currently, the "Persist subtitles" option only works during a single session, so users have to manually enable subtitles if desired every single time the app is restarted, which is not the behavior I expected of such an option, and there's no option to make it persistent across restarts. The reason this happens is that the language of the last selected subtitles is saved to a variable but isn't persisted to storage, which I do in this PR. I didn't make it into a separate option since it doesn't seem to me that the original behavior is intended or useful.

Additionally, since users may watch videos in multiple different languages, I have added a fallback setting for when the chosen language is not found. I originally intended to add a fallback to the original video language (mirroring the original audio setting), but unfortunately the audio tracks don't seem to have an associated language, at least on YouTube. So instead I added a fallback to the first subtitles found, which seems to work as intended (falling back to the original language) in most cases. This option is disabled by default, as enabling it means subtitles will always be enabled if possible.

I believe these changes combined address issue #2706.