### PR TITLE
Remove Downloading List Item Limit

### DIFF
--- a/app/src/main/java/com/futo/platformplayer/fragment/mainactivity/main/DownloadsFragment.kt
+++ b/app/src/main/java/com/futo/platformplayer/fragment/mainactivity/main/DownloadsFragment.kt
@@ -203,7 +203,7 @@ class DownloadsFragment : MainFragment() {
                 _listActiveDownloadsMeta.text = "(${activeDownloads.size} videos)";
 
                 _listActiveDownloads.removeAllViews();
-                for(view in activeDownloads.take(4).map { ActiveDownloadItem(context, it, _frag.lifecycleScope) })
+                for(view in activeDownloads.map { ActiveDownloadItem(context, it, _frag.lifecycleScope) })
                     _listActiveDownloads.addView(view);
             }
 


### PR DESCRIPTION
Removes the limit from the Downloading list, letting more than four elements be shown. With this limit the remaining elements aren't visible or interactable (Cancel button, etc).