### PR TITLE
Fix casting unmuxed-HLS sources (Nebula) to FCast and Chromecast

### DIFF
--- a/app/src/main/java/com/futo/platformplayer/casting/StateCasting.kt
+++ b/app/src/main/java/com/futo/platformplayer/casting/StateCasting.kt
@@ -1060,7 +1060,8 @@ class StateCasting {
                         mediaRendition.type,
                         newPlaylistUrl,
                         mediaRendition.groupID,
-                        mediaRendition.language,
+                        //ChromeCast rejects the "und" language tag
+                        mediaRendition.language?.takeIf { it != "und" },
                         mediaRendition.name,
                         mediaRendition.isDefault,
                         mediaRendition.isAutoSelect,

--- a/app/src/main/java/com/futo/platformplayer/casting/StateCasting.kt
+++ b/app/src/main/java/com/futo/platformplayer/casting/StateCasting.kt
@@ -565,6 +565,23 @@ class StateCasting {
                         Logger.i(TAG, "Casting as raw DASH");
 
                         castDashRaw(contentResolver, video, videoSource as JSDashManifestRawSource?, audioSource as JSDashManifestRawAudioSource?, subtitleSource, resumePosition, speed, castId, onLoadingEstimate, onLoading);
+                    } else if (videoSource is IHLSManifestSource) {
+                        //Some plugins (e.g. Nebula) report unmuxed video+audio that are actually the same HLS manifest - treat as one HLS source
+                        Logger.i(TAG, "Casting as proxied HLS (video+audio both from same HLS manifest)");
+                        val proxyStreams = shouldProxyStreams(ad, videoSource, audioSource)
+                        if (proxyStreams || deviceProto == CastProtocolType.CHROMECAST) {
+                            castProxiedHls(video, videoSource.url, videoSource.codec, resumePosition, speed, (videoSource as? JSSource)?.getRequestModifier());
+                        } else {
+                            ad.loadVideo(if (video.isLive) "LIVE" else "BUFFERED", videoSource.container, videoSource.url, resumePosition, video.duration.toDouble(), speed, metadataFromVideo(video));
+                        }
+                    } else if (audioSource is IHLSManifestAudioSource) {
+                        Logger.i(TAG, "Casting as proxied HLS (audio-only HLS manifest)");
+                        val proxyStreams = shouldProxyStreams(ad, videoSource, audioSource)
+                        if (proxyStreams || deviceProto == CastProtocolType.CHROMECAST) {
+                            castProxiedHls(video, audioSource.url, audioSource.codec, resumePosition, speed, (audioSource as? JSSource)?.getRequestModifier());
+                        } else {
+                            ad.loadVideo(if (video.isLive) "LIVE" else "BUFFERED", audioSource.container, audioSource.url, resumePosition, video.duration.toDouble(), speed, metadataFromVideo(video));
+                        }
                     } else {
                         Logger.i(TAG, "Casting as DASH indirect");
                         castDashIndirect(contentResolver, video, videoSource as IVideoUrlSource?, audioSource as IAudioUrlSource?, subtitleSource, resumePosition, speed);
@@ -935,7 +952,7 @@ class StateCasting {
 
                 val masterPlaylist: HLS.MasterPlaylist
                 try {
-                    masterPlaylist = HLS.parseMasterPlaylist(masterPlaylistContent, sourceUrl)
+                    masterPlaylist = HLS.parseMasterPlaylist(masterPlaylistContent, masterPlaylistResponse.url)
                 } catch (e: Throwable) {
                     if (masterPlaylistContent.lines().any { it.startsWith("#EXTINF:") }) {
                         //This is a variant playlist, not a master playlist
@@ -945,7 +962,7 @@ class StateCasting {
                         vpHeaders["Content-Type"] = "application/vnd.apple.mpegurl";
 
                         val variantPlaylist =
-                            HLS.parseVariantPlaylist(masterPlaylistContent, sourceUrl)
+                            HLS.parseVariantPlaylist(masterPlaylistContent, masterPlaylistResponse.url)
                         val proxiedVariantPlaylist =
                             proxyVariantPlaylist(url, id, variantPlaylist,  video.isLive, requestModifier)
                         val proxiedVariantPlaylist_m3u8 = proxiedVariantPlaylist.buildM3U8()
@@ -989,7 +1006,7 @@ class StateCasting {
                                 ?: throw Exception("Variant playlist content is empty")
 
                             val variantPlaylist =
-                                HLS.parseVariantPlaylist(vpContent, variantPlaylistRef.url)
+                                HLS.parseVariantPlaylist(vpContent, response.url)
                             val proxiedVariantPlaylist =
                                 proxyVariantPlaylist(url, playlistId, variantPlaylist, video.isLive, requestModifier)
                             val proxiedVariantPlaylist_m3u8 = proxiedVariantPlaylist.buildM3U8()
@@ -1029,7 +1046,7 @@ class StateCasting {
                                     ?: throw Exception("Variant playlist content is empty")
 
                                 val variantPlaylist =
-                                    HLS.parseVariantPlaylist(vpContent, mediaRendition.uri)
+                                    HLS.parseVariantPlaylist(vpContent, response.url)
                                 val proxiedVariantPlaylist = proxyVariantPlaylist(
                                     url, playlistId, variantPlaylist, video.isLive, requestModifier
                                 )
@@ -1085,6 +1102,12 @@ class StateCasting {
             newSegments.addAll(variantPlaylist.segments)
         }
 
+        val newMapUrl = if (proxySegments) {
+            variantPlaylist.mapUrl?.let { proxyInitSegment(url, playlistId, it, requestModifier) }
+        } else {
+            variantPlaylist.mapUrl
+        }
+
         return HLS.VariantPlaylist(
             variantPlaylist.version,
             variantPlaylist.targetDuration,
@@ -1093,8 +1116,29 @@ class StateCasting {
             variantPlaylist.programDateTime,
             variantPlaylist.playlistType,
             variantPlaylist.streamInfo,
-            newSegments
+            newSegments,
+            variantPlaylist.decryptionInfo,
+            newMapUrl,
+            variantPlaylist.mapBytesStart,
+            variantPlaylist.mapBytesLength,
+            variantPlaylist.unhandled
         )
+    }
+
+    private fun proxyInitSegment(url: String, playlistId: UUID, mapUrl: String, requestModifier: IRequestModifier?): String {
+        val newSegmentPath = "/hls-playlist-${playlistId}-init"
+        val newSegmentUrl = url + newSegmentPath;
+
+        if (_castServer.getHandler("GET", newSegmentPath) == null) {
+            _castServer.addHandlerWithAllowAllOptions(
+                HttpProxyHandler("GET", newSegmentPath, mapUrl, true)
+                    .withIRequestModifier(requestModifier)
+                    .withInjectedHost()
+                    .withHeader("Access-Control-Allow-Origin", "*"), true
+            ).withTag("castProxiedHlsVariant")
+        }
+
+        return newSegmentUrl
     }
 
     private fun proxySegment(url: String, playlistId: UUID, segment: HLS.Segment, index: Long, requestModifier: IRequestModifier?): HLS.Segment {


### PR DESCRIPTION
Nebula gives video and audio as two sources that are actually the same HLS manifest, which castIfAvailable didn't have a path for - causing an "JSHLSManifestSource" error. Fixing that showed two bugs in castProxiedHls on Chromecast. It resolved playlist-relative URLs against the pre-redirect URL instead of the actual response URL (Nebula's manifest 302s to a different host), and it dropped the EXT-X-MAP init segment when rebuilding the proxied playlist, breaking fMP4 playback. 

Fixes #3239 .

Tested on a Pixel 10 casting Nebula video to both FCast receiver and Chromecast - Nebula videos play correctly on both now. Performed random tests of other sources - they continue to work comparatively to an unmodified version of Grayjay.